### PR TITLE
Fix segfault in NDebugOverlay::Circle when debugoverlay is nullptr

### DIFF
--- a/mp/src/game/shared/debugoverlay_shared.cpp
+++ b/mp/src/game/shared/debugoverlay_shared.cpp
@@ -639,8 +639,11 @@ void NDebugOverlay::Circle( const Vector &position, const Vector &xAxis, const V
 
 		// If we have an alpha value, then draw the fan
 		if ( a && i > 1 )
-		{		
-			debugoverlay->AddTriangleOverlay( vecStart, vecLastPosition, vecPosition, r, g, b, a, bNoDepthTest, flDuration );
+		{
+			if ( debugoverlay )
+			{
+				debugoverlay->AddTriangleOverlay( vecStart, vecLastPosition, vecPosition, r, g, b, a, bNoDepthTest, flDuration );
+			}
 		}
 	}
 }

--- a/sp/src/game/shared/debugoverlay_shared.cpp
+++ b/sp/src/game/shared/debugoverlay_shared.cpp
@@ -639,8 +639,11 @@ void NDebugOverlay::Circle( const Vector &position, const Vector &xAxis, const V
 
 		// If we have an alpha value, then draw the fan
 		if ( a && i > 1 )
-		{		
-			debugoverlay->AddTriangleOverlay( vecStart, vecLastPosition, vecPosition, r, g, b, a, bNoDepthTest, flDuration );
+		{
+			if ( debugoverlay )
+			{
+				debugoverlay->AddTriangleOverlay( vecStart, vecLastPosition, vecPosition, r, g, b, a, bNoDepthTest, flDuration );
+			}
 		}
 	}
 }


### PR DESCRIPTION
The debugoverlay interface global is initialized to nullptr in the dedicated server. All of the NDebugOverlay functions which call into debugoverlay make sure to check whether it's nullptr before calling, with the exception of NDebugOverlay::Circle, which does no such check. This means that certain debug convars can cause the dedicated server to crash (e.g. nb_debug).