### PR TITLE
Add default constructor to NPC_Basedata to prevent uninitialized arms pointer crash

### DIFF
--- a/sp/src/game/server/cbase.h
+++ b/sp/src/game/server/cbase.h
@@ -129,6 +129,14 @@ class CAI_ScriptedSequence;
 class CSound;
 
 struct NPC_Basedata {
+	NPC_Basedata()
+		: nFaction(CLASS_NONE)
+		, iMaxHealth(0)
+		, szModelName(NULL)
+		, szModelArms(NULL)
+	{
+	}
+
 	Class_T nFaction;
 	int iMaxHealth;
 	const char* szModelName;


### PR DESCRIPTION
### Motivation
- `CBasePlayer::SetStats()` reads `data.szModelArms[0]`, and some `GetBaseData()` implementations left `szModelArms` uninitialized which could produce invalid pointer values and cause read-access violations. 

### Description
- Add a default constructor to `NPC_Basedata` in `sp/src/game/server/cbase.h` that initializes fields to safe defaults (`nFaction = CLASS_NONE`, `iMaxHealth = 0`, `szModelName = NULL`, `szModelArms = NULL`).

### Testing
- Verified the patch applied and inspected the updated header with `nl -ba sp/src/game/server/cbase.h` to confirm the new constructor is present; no compile or runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f4a423e4832284ae1a601c3d838b)