### PR TITLE
Use Windows locale-aware date/time formatting for file timestamps in FileOpenDialog

### DIFF
--- a/sp/src/vgui2/vgui_controls/FileOpenDialog.cpp
+++ b/sp/src/vgui2/vgui_controls/FileOpenDialog.cpp
@@ -1121,27 +1121,25 @@ const char *GetFileTimetamp( FILETIME ft )
 	FileTimeToSystemTime( &localFileTime, &local );
 
 	static char out[ 256 ];
+	char dateStr[ 128 ];
+	char timeStr[ 128 ];
 
-	bool am = true;
-	WORD hour = local.wHour;
-	if ( hour >= 12 )
+	int nDateChars = GetDateFormatA( LOCALE_USER_DEFAULT, DATE_SHORTDATE, &local, NULL, dateStr, ARRAYSIZE( dateStr ) );
+	int nTimeChars = GetTimeFormatA( LOCALE_USER_DEFAULT, 0, &local, NULL, timeStr, ARRAYSIZE( timeStr ) );
+	if ( nDateChars > 0 && nTimeChars > 0 )
 	{
-		am = false;
-		// 12:42 pm displays as 12:42 pm
-		// 13:42 pm displays as 1:42 pm
-		if ( hour > 12 )
-		{
-			hour -= 12;
-		}
+		Q_snprintf( out, sizeof( out ), "%s %s", dateStr, timeStr );
 	}
-	Q_snprintf( out, sizeof( out ), "%d/%02d/%04d %d:%02d %s",
-		local.wMonth, 
-		local.wDay,
-		local.wYear,
-		hour,
-		local.wMinute,
-		am ? "AM" : "PM" // TODO: Localize this?
-		);
+	else
+	{
+		// Fallback formatting (US) for environments where locale APIs fail.
+		Q_snprintf( out, sizeof( out ), "%d/%02d/%04d %02d:%02d",
+			local.wMonth,
+			local.wDay,
+			local.wYear,
+			local.wHour,
+			local.wMinute );
+	}
 	return out;
 }
 #endif


### PR DESCRIPTION
### Motivation
- Replace manual AM/PM and 12-hour conversion with locale-aware formatting so file timestamps respect the user's regional settings and avoid formatting bugs.

### Description
- In `GetFileTimetamp` added `dateStr` and `timeStr` buffers and call `GetDateFormatA` and `GetTimeFormatA` with `LOCALE_USER_DEFAULT` to format the timestamp.
- When both format API calls succeed the code now composes the timestamp with `Q_snprintf("%s %s", dateStr, timeStr)` and otherwise falls back to a numeric `MM/DD/YYYY HH:MM` formatting.
- Removed the old manual 12-hour/AM-PM conversion and the previous `Q_snprintf` that constructed the AM/PM string, simplifying the function.

### Testing
- Built the project on Windows and launched the file open dialog to verify timestamps render using the OS locale without crashes.
- Executed the repository's automated test suite related to the UI/timestamp code paths and observed no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022e1bd1288322810a1174b5e0751e)